### PR TITLE
first cut: Cassandra flows with support for conditional writes

### DIFF
--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
@@ -35,6 +35,21 @@ object CassandraFlow {
       )
       .asJava
 
+  def createConditional[T](
+      session: CassandraSession,
+      writeSettings: CassandraWriteSettings,
+      cqlStatement: String,
+      statementBinder: akka.japi.Function2[T, PreparedStatement, BoundStatement]
+  ): Flow[T, ConditionalWriteResult[T], NotUsed] =
+    scaladsl.CassandraFlow
+      .createConditional(
+        writeSettings,
+        cqlStatement,
+        (t, preparedStatement) => statementBinder.apply(t, preparedStatement)
+      )(session.delegate)
+      .map(ConditionalWriteResultBuilder.fromEither)
+      .asJava
+
   /**
    * A flow writing to Cassandra for every stream element, passing context along.
    * The element (to be persisted) and the context are emitted unchanged.
@@ -58,6 +73,22 @@ object CassandraFlow {
       )
       .asJava
   }
+
+  def withContextConditional[T, Ctx](
+      session: CassandraSession,
+      writeSettings: CassandraWriteSettings,
+      cqlStatement: String,
+      statementBinder: akka.japi.Function2[T, PreparedStatement, BoundStatement]
+  ): FlowWithContext[T, Ctx, ConditionalWriteResult[T], Ctx, NotUsed] =
+    scaladsl.CassandraFlow
+      .withContextConditional(
+        writeSettings,
+        cqlStatement,
+        (t, preparedStatement) => statementBinder.apply(t, preparedStatement)
+      )(session.delegate)
+      .map(ConditionalWriteResultBuilder.fromEither)
+      .asJava
+
 
   /**
    * Creates a flow that uses [[com.datastax.oss.driver.api.core.cql.BatchStatement]] and groups the

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSession.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraSession.scala
@@ -18,6 +18,7 @@ import akka.Done
 import akka.NotUsed
 import akka.actor.{ActorSystem, ClassicActorSystemProvider}
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
 import akka.event.LoggingAdapter
 import akka.stream.alpakka.cassandra.CassandraServerMetaData
 import akka.stream.alpakka.cassandra.{scaladsl, CqlSessionProvider}
@@ -156,6 +157,17 @@ final class CassandraSession(@InternalApi private[akka] val delegate: scaladsl.C
   @varargs
   def executeWrite(stmt: String, bindValues: AnyRef*): CompletionStage[Done] =
     delegate.executeWrite(stmt, bindValues: _*).toJava
+
+  def executeConditionalWrite(stmt: Statement[_]): CompletionStage[ConditionalWriteResult[Done]] =
+    delegate.executeConditionalWrite(stmt)
+      .map(ConditionalWriteResultBuilder.fromEither)(ExecutionContexts.parasitic)
+      .toJava
+
+  @varargs
+  def executeConditionalWrite(stmt: String, bindValues: AnyRef*): CompletionStage[ConditionalWriteResult[Done]] =
+    delegate.executeConditionalWrite(stmt, bindValues: _*)
+      .map(ConditionalWriteResultBuilder.fromEither)(ExecutionContexts.parasitic)
+      .toJava
 
   /**
    * Execute a select statement. First you must `prepare` the

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/ConditionalResult.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/javadsl/ConditionalResult.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.cassandra.javadsl
+
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet
+
+import scala.util.Either
+
+trait ConditionalWriteResult[T] {
+  def wasApplied: Boolean
+
+  @throws(classOf[NoSuchElementException])
+  def getContents: T
+
+  @throws(classOf[NoSuchElementException])
+  def getResultSet: AsyncResultSet
+}
+
+final class AppliedConditionalWriteResult[T](contents: T) extends ConditionalWriteResult[T] {
+  def wasApplied: Boolean = true
+
+  @throws(classOf[NoSuchElementException])
+  override def getContents: T = contents
+
+  @throws(classOf[NoSuchElementException])
+  override def getResultSet: AsyncResultSet =
+    throw new NoSuchElementException("No result set from Cassandra - conditional write was applied")
+}
+
+final class UnappliedConditionalWriteResult[T](resultSet: AsyncResultSet) extends ConditionalWriteResult[T] {
+  def wasApplied: Boolean = false
+  
+  @throws(classOf[NoSuchElementException])
+  override def getContents: T =
+    throw new NoSuchElementException("Conditional write was not applied")
+
+  @throws(classOf[NoSuchElementException])
+  override def getResultSet: AsyncResultSet = resultSet
+}
+
+object ConditionalWriteResultBuilder {
+  def applied[T](contents: T): AppliedConditionalWriteResult[T] = new AppliedConditionalWriteResult(contents)
+  def unapplied[T](asyncResultSet: AsyncResultSet): UnappliedConditionalWriteResult[T] =
+    new UnappliedConditionalWriteResult(asyncResultSet)
+
+  def fromEither[T](either: Either[T, AsyncResultSet]): ConditionalWriteResult[T] =
+    either.fold(applied, unapplied)
+}

--- a/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraFlow.scala
+++ b/cassandra/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraFlow.scala
@@ -8,7 +8,12 @@ import akka.NotUsed
 import akka.dispatch.ExecutionContexts
 import akka.stream.alpakka.cassandra.CassandraWriteSettings
 import akka.stream.scaladsl.{Flow, FlowWithContext}
-import com.datastax.oss.driver.api.core.cql.{BatchStatement, BoundStatement, PreparedStatement}
+import com.datastax.oss.driver.api.core.cql.{
+  AsyncResultSet,
+  BatchStatement,
+  BoundStatement,
+  PreparedStatement
+}
 
 import scala.jdk.CollectionConverters._
 import scala.concurrent.Future
@@ -47,6 +52,25 @@ object CassandraFlow {
       .mapMaterializedValue(_ => NotUsed)
   }
 
+  def createConditional[T](
+    writeSettings: CassandraWriteSettings,
+    cqlStatement: String,
+    statementBinder: (T, PreparedStatement) => BoundStatement
+  )(implicit session: CassandraSession): Flow[T, Either[T, AsyncResultSet], NotUsed] = {
+    Flow
+      .lazyFutureFlow { () =>
+        val prepare = session.prepare(cqlStatement)
+        prepare.map { preparedStatement =>
+          Flow[T].mapAsync(writeSettings.parallelism) { element =>
+            session
+              .executeConditionalWrite(statementBinder(element, preparedStatement))
+              .map(_.left.map(_ => element))(ExecutionContexts.parasitic)
+          }
+        }(session.ec)
+      }
+      .mapMaterializedValue(_ => NotUsed)
+  }
+
   /**
    * A flow writing to Cassandra for every stream element, passing context along.
    * The element (to be persisted) and the context are emitted unchanged.
@@ -73,6 +97,28 @@ object CassandraFlow {
                 session
                   .executeWrite(statementBinder(element, preparedStatement))
                   .map(_ => tuple)(ExecutionContexts.parasitic)
+            }
+          }(session.ec)
+        }
+        .mapMaterializedValue(_ => NotUsed)
+    }
+  }
+
+  def withContextConditional[T, Ctx](
+    writeSettings: CassandraWriteSettings,
+    cqlStatement: String,
+    statementBinder: (T, PreparedStatement) => BoundStatement
+  )(implicit session: CassandraSession): FlowWithContext[T, Ctx, Either[T, AsyncResultSet], Ctx, NotUsed] = {
+    FlowWithContext.fromTuples {
+      Flow
+        .lazyFutureFlow { () =>
+          val prepare = session.prepare(cqlStatement)
+          prepare.map { preparedStatement =>
+            Flow[(T, Ctx)].mapAsync(writeSettings.parallelism) {
+              case (element, ctx) =>
+              session
+                .executeConditionalWrite(statementBinder(element, preparedStatement))
+                .map(_.left.map(_ => element) -> ctx)(ExecutionContexts.parasitic)
             }
           }(session.ec)
         }


### PR DESCRIPTION
"Conditional" write flows result in `Either[T, AsyncResultSet]`: the `Left[T]` case is for when the write was applied, the `Right[AsyncResultSet]` case is when the write wasn't applied (e.g. in an `INSERT ... IF NOT EXISTS` there was already a row).  Per the Cassandra docs around `wasApplied`, if the query is an unconditional write, this will always be a `Left` (for those, the conditional version of the flow is effectively just a less efficient version (extra wrapping/unwrapping) of the existing flow).  I'm open to flipping the `Either`, but my sense is that this doesn't perfectly map onto the usual right-biasing conventions (the more interesting result is the `AsyncResultSet` IMO, even though that could be thought of as the failure).

The Java API is a work in progress: this feels like how a sum type would be encoded in a lightweight way in Java and I don't know if it makes sense to expose functional combinators: since the typical next stage in the Scala API would be a `fold`, I think Java code like:

```java
if (element.wasApplied()) {
    // do stuff with element.getContents()
} else {
    // do stuff with element.getResultSet()
}
```

Perhaps the `fold` could be incorporated into the stage by requiring an `AsyncResultSet => T`, but that actually seems like a fairly niche use case.